### PR TITLE
Fix link to the WakaTime website

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
                 <img src="img/icon/modrinth.svg" alt="Modrinth" draggable="false" loading="lazy">
                 <span>Modrinth</span>
             </a>
-            <a href="https://modrinth.com/user/YouHaveTrouble" class="social-link" target="_blank" rel="external">
+            <a href="https://wakatime.com/@YouHaveTrouble" class="social-link" target="_blank" rel="external">
                 <img src="img/icon/wakatime.svg" alt="WakaTime" draggable="false" loading="lazy">
                 <span>WakaTime</span>
             </a>


### PR DESCRIPTION
Currently icon which should points to the WakaTime website, points to the Modrinth.

This PR fix that by providing correct link to YouHaveTrouble WakaTime profile.